### PR TITLE
fix: use square icon image to fix squished logo in header

### DIFF
--- a/.claude/commands/dev:report-bug.md
+++ b/.claude/commands/dev:report-bug.md
@@ -1,0 +1,70 @@
+# Report a Bug
+
+Collect a structured bug report from the user and create a bug ticket in Linear.
+
+## Workflow
+
+1. **Gather Information** - Ask diagnostic questions
+2. **Verify Details** - Confirm reproduction steps
+3. **Create Issue** - Use Linear skill for ticket creation
+
+## Required Information
+
+- Bug summary (one sentence)
+- Expected vs actual behavior
+- Steps to reproduce
+- Error messages/stack traces (if any)
+- Environment (browser, OS, affected area)
+
+## Diagnostic Questions
+
+1. "What were you trying to do?"
+2. "What did you expect to happen?"
+3. "What actually happened?"
+4. "Can you reproduce this consistently?"
+5. "Are there any error messages?"
+
+## Context Gathering
+
+Check these locations:
+- Browser console for client errors
+- Server logs (`pnpm dev` output)
+- Network tab for failed requests
+
+## Severity Guidelines
+
+| Severity | Criteria |
+|----------|----------|
+| Critical | App crashes, data loss, security issue |
+| High | Feature broken, no workaround |
+| Medium | Feature broken, has workaround |
+| Low | Cosmetic, minor inconvenience |
+
+## Issue Description Template
+
+Use this format when creating the Linear issue:
+
+```
+## Summary
+[One sentence description]
+
+## Expected Behavior
+[What should happen]
+
+## Actual Behavior
+[What happens instead]
+
+## Steps to Reproduce
+1. ...
+2. ...
+
+## Environment
+- Browser/OS:
+- Affected area:
+
+## Error Details
+[Stack traces, console errors]
+```
+
+---
+Context: $ARGUMENTS

--- a/apps/web/modules/shared/components/Logo.tsx
+++ b/apps/web/modules/shared/components/Logo.tsx
@@ -16,7 +16,7 @@ export function Logo({
 			)}
 		>
 			<Image
-				src="/images/logo.png"
+				src="/images/icon-sd.png"
 				alt="Software Multitool"
 				width={40}
 				height={40}


### PR DESCRIPTION
## Summary

- Fixed the squished logo in the header by changing from `logo.png` to `icon-sd.png`
- `logo.png` (2112x1152, ~1.83:1 aspect ratio) was being forced into a 40x40 square container
- `icon-sd.png` (523x523, perfect square) displays correctly in the square container

## Related Issue

Closes PRA-36

## Test Plan

- Verified `icon-sd.png` exists and is 523x523 (square)
- All tests pass (88 API tests + 2 web tests)
- Visual check: Logo should appear as a proper square icon without distortion

🤖 Generated with [Claude Code](https://claude.com/claude-code)