### PR TITLE
chore: ignore Prisma in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     ignore:
       - dependency-name: "cropperjs"
         versions: [">1.6.2"]
+      # Prisma 6.x/7.x has breaking changes in client generation
+      # Re-enable once upstream compatibility issues are resolved
+      - dependency-name: "prisma"
+      - dependency-name: "@prisma/client"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary
- Ignore `prisma` and `@prisma/client` packages in Dependabot updates
- Prisma 6.x/7.x has breaking changes causing CI failures

## Context
Closed failing Dependabot PRs:
- #1 - Bump the production-dependencies group with 59 updates
- #2 - Bump the development-dependencies group with 22 updates

Both failed due to:
- `ENOENT: no such file or directory, copyfile .../library.d.ts`
- `unknown or unexpected option: --postinstall`

## Test plan
- [ ] Verify Dependabot no longer creates PRs for Prisma updates
- [ ] Production builds remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)