### PR TITLE
chore: ignore major version bumps with breaking changes in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,21 @@ updates:
       # Re-enable once upstream compatibility issues are resolved
       - dependency-name: "prisma"
       - dependency-name: "@prisma/client"
+      # Next.js 16 has breaking changes - handle manually when ready
+      - dependency-name: "next"
+        versions: [">=16.0.0"]
+      # Fumadocs 16 has breaking import path changes
+      - dependency-name: "fumadocs-core"
+        versions: [">=16.0.0"]
+      - dependency-name: "fumadocs-ui"
+        versions: [">=16.0.0"]
+      - dependency-name: "@fumadocs/*"
+        versions: [">=2.0.0"]
+      # AI SDK v6 / @ai-sdk v3 have breaking API changes
+      - dependency-name: "ai"
+        versions: [">=6.0.0"]
+      - dependency-name: "@ai-sdk/*"
+        versions: [">=3.0.0"]
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
## Summary
- Add ignore rules for packages with known breaking API changes to prevent large, failing Dependabot PRs
- Closes the gap that caused PR #6 to fail with 58 bundled updates

**Packages now ignored until ready for manual migration:**
- `next` >=16.0.0
- `fumadocs-core/ui` >=16.0.0, `@fumadocs/*` >=2.0.0
- `ai` >=6.0.0, `@ai-sdk/*` >=3.0.0

## Test plan
- [x] Verify dependabot.yml syntax is valid
- [ ] Future Dependabot runs will skip these major versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)