### PR TITLE
feat(content): revise week-3 post - Honest Guide to AI Transcription (publish Apr 15)

### DIFF
--- a/apps/web/content/posts/best-ai-transcription-software-2025.mdx
+++ b/apps/web/content/posts/best-ai-transcription-software-2025.mdx
@@ -1,129 +1,124 @@
 ---
-title: "Best AI Transcription Software in 2025: A Practical Comparison"
-excerpt: "Comparing the top AI transcription tools for accuracy, speaker identification, turnaround time, and price — for businesses that transcribe regularly."
-date: "2026-03-24"
+title: "The Honest Guide to AI Transcription Software in 2025"
+excerpt: "What the accuracy benchmarks don't tell you, where speaker separation actually breaks down, and how to choose the right tool for your specific audio — not the demo audio."
+date: "2026-04-15"
 authorName: "Software Multi-Tool Team"
 authorImage: "/images/blog/default-author.png"
-tags: ["transcription", "ai-tools", "comparison", "productivity"]
+tags: ["transcription", "ai-tools", "speaker-separation", "comparison"]
 published: false
 ---
 
-AI transcription has gotten good enough that most businesses no longer need human transcriptionists for routine audio. But not all AI transcription tools are created equal — they differ significantly in accuracy, speaker identification, turnaround time, file format support, and price.
+AI transcription is good enough that most businesses no longer need human transcriptionists for routine audio. But "good enough" covers a huge range, and the gap between marketing claims and real-world performance is wider in transcription than in almost any other AI category.
 
-This guide compares the most-used AI transcription tools in 2025 and helps you figure out which is right for your use case.
+This guide is for teams who need to make a real decision — not just read benchmarks.
 
-## What to Look for in AI Transcription Software
+## The Accuracy Benchmark Problem
 
-Before comparing tools, it's worth being clear about your requirements:
+Every transcription vendor leads with accuracy numbers. "98% accurate." "Industry-leading accuracy." Sometimes a WER (Word Error Rate) comparison against competitors.
 
-**Accuracy at scale:** How accurate is it on your audio? Conference calls, interviews, customer calls, and recorded meetings all have different acoustic characteristics. Accuracy claims in marketing copy rarely tell you how the tool performs on your specific content.
+Here's the problem: those benchmarks are measured on clean audio with a single native English speaker in a quiet room. That's not your audio.
 
-**Speaker identification:** If your recordings have multiple speakers, does the tool identify and label each speaker separately? This is critical for meeting notes, interviews, and customer call analysis.
+Real-world accuracy drops significantly for:
 
-**Turnaround time:** Do you need real-time transcription, or is a 5–10 minute turnaround acceptable? Real-time is harder and generally less accurate.
+- **Non-native English speakers or strong regional accents** — most models are trained primarily on American/British English. Results vary widely for Indian, Nigerian, Brazilian, or Eastern European accents.
+- **Technical vocabulary** — legal, medical, or financial jargon requires either fine-tuned models or custom vocabulary support. "Indemnification clause" and "amortization schedule" don't appear in standard training sets at the same frequency as "meeting" and "calendar."
+- **Overlapping speakers** — crosstalk in a group call is genuinely hard. Most tools handle it by picking the dominant voice or silently dropping the other.
+- **Poor recording quality** — phone calls recorded at 8kHz, outdoor interviews with wind, or room echo in a conference room all reduce accuracy materially.
+- **Multiple languages** — mixed-language conversations are essentially unsupported in most tools.
 
-**File format support:** Can it handle MP3, MP4, WAV, M4A, and video formats? Some tools have narrow format support.
+The honest takeaway: **test any tool with your actual audio before committing**. A 60-minute recording at 90% accuracy has roughly 540 word errors. At 95%, that drops to 270. At 98%, it's 108. The difference between those is a huge editing burden at scale.
 
-**Output format:** Do you need plain text, structured summaries, or actionable insights? Basic transcription tools output raw text. More advanced tools generate summaries, action items, and speaker-attributed excerpts.
+## Speaker Separation: Where It Works and Where It Doesn't
 
-**Integration:** Does it need to connect to your existing tools (Zoom, Google Meet, CRM, Slack)?
+Plain transcription gives you a wall of text. Speaker-separated transcription gives you a structured conversation you can actually use.
 
-**Pricing:** Per-minute, per-hour, or subscription? For high-volume use, per-minute pricing gets expensive quickly.
+For most business use cases, speaker attribution is the feature that makes transcription valuable rather than just a service you pay for:
 
-## The Main Categories of AI Transcription Tools
+- Meeting notes become navigable: "What did the client say about the deadline?"
+- Customer calls can be scored by agent vs. customer behavior
+- Earnings calls become structured Q&A, not a 90-minute text block
+- Interviews can be analyzed at the respondent level
 
-### 1. Meeting-First Tools (Zoom/Teams/Meet Integration)
-**Examples:** Otter.ai, Fireflies, Fathom, tl;dv
+**How speaker separation actually works:** Modern tools use a technique called speaker diarization — the audio is analyzed to identify when the speaker changes, and each segment is assigned a label (Speaker 1, Speaker 2, etc.). In a second pass, the transcript is aligned to those labels.
 
-These tools connect directly to your video conferencing platform and transcribe in real-time. They're optimized for meeting recordings and typically include features like action item extraction and searchable meeting history.
+**Where it breaks down:**
+- Two speakers with similar vocal characteristics (same gender, similar age, similar pitch)
+- Long segments where a speaker pauses frequently (some models split a single speaker into multiple labels)
+- More than ~6 speakers — most tools degrade significantly above 4–6 people
+- Back-channel responses ("uh-huh", "right", "mm") — often attributed incorrectly
 
-**Best for:** Teams with predictable meeting cadences who want automatic transcription of every call.
+The [speaker separation tool](/tools/speaker-separation) on this platform processes audio files and returns a labeled JSON transcript with per-speaker segments. For meeting workflows, it feeds directly into the [meeting summarizer](/tools/meeting-summarizer), which produces speaker-attributed summaries rather than a single narrative.
 
-**Limitations:** Less useful for audio that isn't a Zoom/Teams/Meet call — field recordings, customer service calls, audio interviews, etc.
+## The Main Tool Categories
 
-### 2. General Audio Transcription Tools
-**Examples:** Rev, Sonix, Descript, Software Multi-Tool
+### Meeting-First Tools (Otter, Fireflies, Fathom, tl;dv)
 
-These tools handle any audio or video file you upload. They're format-agnostic and typically include speaker diarization (speaker separation) as a feature.
+Connect to Zoom, Teams, or Meet and transcribe automatically. Optimized for meeting recordings with action item extraction, searchable history, and calendar integration.
 
-**Best for:** Irregular or varied transcription needs — interviews, depositions, podcast editing, earnings call transcription, field recordings.
+**Useful when:** Your transcription need is primarily Zoom/Teams meetings and you want zero friction. The integration is the value — you don't think about transcription, it just happens.
 
-**Limitations:** No real-time option (you upload a file, wait for output).
+**Not useful for:** Any audio that isn't a video call. Field recordings, customer service phone calls, uploaded audio files, podcast editing — these tools aren't built for that workflow.
 
-### 3. API-First Tools (for Developers)
-**Examples:** Deepgram, AssemblyAI, OpenAI Whisper API
+### General Audio Upload Tools (Rev, Sonix, Descript)
 
-These are developer-oriented APIs that give you raw transcription output for building into your own applications. High accuracy, customizable, but not designed for non-technical end users.
+Handle any audio or video file. Format-agnostic with speaker diarization and usually some form of summary output.
 
-**Best for:** Developers building transcription into a product, or teams with technical staff who want maximum control.
+**Useful when:** You have varied audio types or non-meeting recordings. Interviews, depositions, earnings calls, customer calls.
 
-### 4. Human + AI Hybrid Services
-**Examples:** Rev Human Transcription, Scribie
+**Pricing reality:** Per-minute pricing adds up. 10 hours/month of audio at $0.15/minute is $90/month. That's before you account for re-processing anything that comes back with bad speaker attribution.
 
-These supplement AI transcription with human review for higher accuracy guarantees (99%+). Slower (24–48 hours) and more expensive, but useful for legally sensitive or high-stakes content.
+### API-First Tools (Deepgram, AssemblyAI, OpenAI Whisper)
 
-**Best for:** Legal depositions, medical records, court proceedings where accuracy requirements are strict.
+Raw transcription APIs for developers building transcription into applications. High accuracy, customizable, but not designed for business users clicking buttons.
 
-## Accuracy Reality Check
+**Useful when:** You have a technical team and want control over the full pipeline — custom vocabulary, confidence scores, word-level timestamps, or on-premises deployment.
 
-Accuracy benchmarks quoted by transcription tools are almost always measured on clean, studio-quality audio with a single native English speaker. Real-world accuracy is lower, especially for:
+### Human + AI Hybrid (Rev Human, Scribie)
 
-- **Accented speech:** Non-native English speakers, regional accents
-- **Technical vocabulary:** Legal, medical, financial jargon
-- **Overlapping speakers:** Crosstalk in group meetings
-- **Poor audio quality:** Phone calls, outdoor recordings, background noise
-- **Multiple languages:** Mixed-language conversations
+AI transcription reviewed and corrected by humans. 99%+ accuracy. 24–48 hour turnaround. $1.00–$1.50/minute.
 
-If you're transcribing customer calls, field recordings, or international team meetings, test any tool with your actual audio before committing. The difference between 90% and 95% accuracy sounds small — on a 60-minute transcript, that's 3x as many errors to correct.
+**Useful when:** Accuracy is non-negotiable — legal depositions, medical records, anything that will be submitted as an official document or used in litigation.
 
-## Speaker Separation: Why It Matters
+## Pricing Reality Check (2025)
 
-Plain transcription gives you a wall of text. Speaker-separated transcription gives you a structured conversation.
-
-For meeting notes, speaker attribution lets you quickly answer:
-- "What did the client say about the timeline?"
-- "What did our account manager commit to?"
-- "What did the CEO say vs. the CFO in this earnings call?"
-
-For customer call analysis, speaker separation distinguishes agent and customer, which is required for most call quality scoring workflows.
-
-The [speaker separation tool](/tools/speaker-separation) processes audio with multiple speakers and outputs a labeled transcript where each segment is attributed to a specific speaker. For meeting summarization workflows, this feeds directly into downstream summarization — you get both the raw transcript and a structured summary with speaker attribution.
-
-## Choosing Based on Use Case
-
-**Weekly team meetings (5–20 people):** Meeting-first tools like Otter, Fireflies, or Fathom. The integration with Zoom/Teams is the primary value.
-
-**Customer service call transcription:** General audio tools with speaker separation. Volume-based pricing matters — look at per-minute rates.
-
-**Earnings call analysis:** General audio tools with summarization output. Speaker attribution for CEO/CFO/analyst segments is valuable.
-
-**Legal depositions or expert witness interviews:** Human + AI hybrid for accuracy requirements. Document everything carefully.
-
-**Podcast production:** Descript or general tools with editing-friendly output. You'll want word-level timestamps for audio editing.
-
-**Field research or interviews:** General audio tools. Test accuracy on your specific subject matter and speaker backgrounds.
-
-**Developer integration:** Deepgram or AssemblyAI for API access. OpenAI Whisper for on-premises or high-volume batch processing.
-
-## Pricing Overview (2025)
-
-| Category | Typical Price Range |
+| Category | Typical Pricing |
 |---|---|
 | Meeting tools (subscription) | $10–$20/user/month |
-| General audio tools (per minute) | $0.02–$0.25/minute |
-| API-first tools | $0.01–$0.05/minute |
+| General audio tools | $0.02–$0.25/minute |
+| API-first | $0.006–$0.05/minute |
 | Human + AI hybrid | $1.00–$1.50/minute |
 
-For a team that transcribes 10 hours of audio per month, the difference between the cheapest and most expensive options can be $50–$1,000+ per month. Volume matters significantly to total cost.
+For a team transcribing 10 hours/month: the gap between cheapest ($12) and most expensive ($900) is enormous. Volume changes the math significantly — most per-minute tools offer bulk pricing.
 
-## Getting Started
+One thing that doesn't show up in pricing tables: **editing time**. A transcript at 92% accuracy that takes 30 minutes to correct may cost more in staff time than one at 97% accuracy that takes 5 minutes — even if the per-minute rate is twice as high.
 
-The fastest way to find the right transcription tool is to test 2–3 options with the same audio sample — ideally a real recording from your typical use case.
+## Choosing by Use Case
 
-Most tools offer free trials or free tiers. Take 30 minutes to run the same 15-minute audio through multiple tools and compare output quality, speaker attribution accuracy, and turnaround time.
+**Weekly team meetings:** Meeting-first tools. The integration is the value. Use Otter, Fireflies, or Fathom.
 
-For teams that need transcription + summarization in a single workflow, the [meeting summarizer](/tools/meeting-summarizer) handles both — transcribing audio and generating a structured summary with speaker-attributed sections and action items.
+**Customer service calls (high volume):** General tools with per-minute pricing or API access. Test speaker attribution on agent/customer separation specifically — this varies a lot between tools.
+
+**Earnings call analysis:** General tools with summarization output. Speaker attribution for analyst Q&A sections matters.
+
+**Podcast editing:** Descript's word-level editing workflow is genuinely different from other tools and worth evaluating separately.
+
+**Legal depositions or court proceedings:** Human + AI hybrid only. The accuracy bar is different.
+
+**Field research or interviews:** General audio tools. Test with recordings that match your speaker demographics — accent/dialect support varies widely.
+
+**Developer integration or batch processing:** Deepgram or AssemblyAI for API access. OpenAI Whisper (open source) for on-premises or cost-sensitive batch workflows.
+
+## The Right Test
+
+Before choosing any transcription tool:
+
+1. Take a real recording from your actual use case — not a clean demo file
+2. Run it through 2–3 tools simultaneously
+3. Compare: accuracy on your vocabulary, speaker attribution correctness, turnaround time
+4. Calculate total cost including editing time, not just per-minute pricing
+
+Most tools offer free trials or small free tiers. 30 minutes of testing on your audio will tell you more than any vendor comparison.
 
 ---
 
-*Software Multi-Tool offers AI transcription, speaker separation, and meeting summarization tools. [Try free](/auth/signup).*
+For teams that need transcription and summarization together — upload audio, get a speaker-labeled summary with action items — the [meeting summarizer](/tools/meeting-summarizer) handles both in one step. [Try it free](/auth/signup).


### PR DESCRIPTION
Week 3 of the content calendar (2026-04-15). Revised `best-ai-transcription-software-2025.mdx` with sharpened title, honest accuracy analysis, concrete speaker separation caveats, and use-case routing. Post is still `published: false` — set to `true` on publish date.