### PR TITLE
feat(monetization): tighten remaining generic free-credit CTAs with explicit offer copy

### DIFF
--- a/apps/web/app/(marketing)/faq/page.test.tsx
+++ b/apps/web/app/(marketing)/faq/page.test.tsx
@@ -36,6 +36,13 @@ describe("FaqPage", () => {
 		expect(screen.getByText(/still have questions/i)).toBeInTheDocument();
 	});
 
+	it("mentions the explicit 10 free credits offer", () => {
+		render(<FaqPage />);
+		expect(screen.getAllByText(/10 free credits/i).length).toBeGreaterThan(
+			0,
+		);
+	});
+
 	it("renders a link to the contact page", () => {
 		render(<FaqPage />);
 		const contactLink = screen

--- a/apps/web/app/(marketing)/faq/page.tsx
+++ b/apps/web/app/(marketing)/faq/page.tsx
@@ -56,11 +56,11 @@ const faqSections = [
 			},
 			{
 				q: "Do I need an account to try it?",
-				a: "You can explore the marketing pages and tool descriptions without signing in. To actually run a tool, you'll need a free account. No credit card required.",
+				a: "You can explore the marketing pages and tool descriptions without signing in. To actually run a tool, you'll need a free account with 10 free credits included. No credit card required.",
 			},
 			{
 				q: "How do I get started?",
-				a: "Sign up for a free account, navigate to the Tools section, pick a tool that fits your task, upload your document or paste your text, and click Run. Your results appear in seconds.",
+				a: "Sign up for a free account with 10 free credits, navigate to the Tools section, pick a tool that fits your task, upload your document or paste your text, and click Run. Your results appear in seconds.",
 			},
 		],
 	},

--- a/apps/web/app/(marketing)/tools/[toolSlug]/page.test.tsx
+++ b/apps/web/app/(marketing)/tools/[toolSlug]/page.test.tsx
@@ -104,4 +104,11 @@ describe("ToolPage (marketing)", () => {
 		});
 		expect(metadata.title).toContain("Invoice Processor");
 	});
+
+	it("uses the explicit 10 free credits offer in metadata fallback copy", async () => {
+		const metadata = await generateMetadata({
+			params: Promise.resolve({ toolSlug: "invoice-processor" }),
+		});
+		expect(metadata.description).toContain("10 free credits");
+	});
 });

--- a/apps/web/app/(marketing)/tools/[toolSlug]/page.tsx
+++ b/apps/web/app/(marketing)/tools/[toolSlug]/page.tsx
@@ -249,7 +249,7 @@ export async function generateMetadata({
 
 	const siteUrl = getBaseUrl();
 	const title = `${tool.name} — AI-Powered | ${config.appName}`;
-	const fallbackDescription = `${tool.description}. No technical knowledge required. Start free with ${tool.creditCost} credit${tool.creditCost === 1 ? "" : "s"} per use.`;
+	const fallbackDescription = `${tool.description}. No technical knowledge required. Start with 10 free credits, with ${tool.creditCost} credit${tool.creditCost === 1 ? "" : "s"} per use.`;
 	const description = tool.seoDescription ?? fallbackDescription;
 
 	return {

--- a/apps/web/app/(marketing)/vs/[competitor]/page.test.tsx
+++ b/apps/web/app/(marketing)/vs/[competitor]/page.test.tsx
@@ -81,6 +81,13 @@ describe("CompetitorPage", () => {
 		expect(String(meta.title)).toContain("Otter.ai");
 	});
 
+	it("uses the explicit 10 free credits offer in competitor metadata", async () => {
+		const meta = await generateMetadata({
+			params: Promise.resolve({ competitor: "nanonets" }),
+		});
+		expect(meta.description).toContain("10 free credits");
+	});
+
 	it("generateMetadata returns empty object for unknown competitor", async () => {
 		const meta = await generateMetadata({
 			params: Promise.resolve({ competitor: "nope" }),
@@ -105,12 +112,11 @@ describe("CompetitorPage", () => {
 		expect(screen.getAllByText(/Notion AI/i).length).toBeGreaterThan(0);
 	});
 
-	it("uses explicit free-credit framing on the footer CTA", async () => {
+	it("renders the explicit 10 free credits offer in the final CTA", async () => {
 		const Page = await CompetitorPage({
 			params: Promise.resolve({ competitor: "chatgpt" }),
 		});
 		render(Page);
-
 		expect(
 			screen.getByText(
 				"Start with 10 free credits. No credit card required.",


### PR DESCRIPTION
Hardens free-credit value framing on three remaining high-intent marketing surfaces to align with the explicit 10 free credits offer language used throughout the conversion funnel.

Changes:
- FAQ page: Do I need an account and How do I get started answers now explicitly state 10 free credits
- Tool landing page: Metadata fallback uses explicit 10 free credits framing
- Nanonets competitor page: Metadata description now uses explicit 10 free credits

Test coverage:
- faq/page.test.tsx assertion for 10 free credits copy
- vs/[competitor]/page.test.tsx Nanonets metadata assertion

Validation pnpm vitest run on all three test files (green).