### PR TITLE
feat(pricing): clarify free vs trial CTA copy

### DIFF
--- a/apps/web/modules/marketing/home/components/StickyCta.test.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.test.tsx
@@ -59,7 +59,7 @@ describe("StickyCta", () => {
 
 	it("is not visible initially (scrollY = 0)", () => {
 		render(<StickyCta />);
-		expect(screen.queryByText(/start free/i)).toBeNull();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
 	});
 
 	it("becomes visible for anonymous user (no balance) when scrollY > 400", () => {
@@ -71,7 +71,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.getByText(/start free/i)).toBeTruthy();
+		expect(screen.getByText(/Get 10 free credits/i)).toBeTruthy();
 	});
 
 	it("becomes visible for free-plan user when scrollY > 400", () => {
@@ -83,7 +83,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.getByText(/start free/i)).toBeTruthy();
+		expect(screen.getByText(/Get 10 free credits/i)).toBeTruthy();
 	});
 
 	it("shows Starter→Pro upsell CTA for Starter plan users", () => {
@@ -112,7 +112,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.queryByText(/start free/i)).toBeNull();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
 	});
 
 	it("is hidden for Pro (paid) user even when scrollY > 400", () => {
@@ -124,7 +124,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.queryByText(/start free/i)).toBeNull();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
 		expect(screen.queryByText(/upgrade to pro/i)).toBeNull();
 	});
 
@@ -138,7 +138,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.getByText(/start free/i)).toBeTruthy();
+		expect(screen.getByText(/Get 10 free credits/i)).toBeTruthy();
 	});
 
 	it("contains a signup link for anonymous/free users", () => {
@@ -166,6 +166,6 @@ describe("StickyCta", () => {
 		scrollPast400();
 		const dismissBtn = screen.getByRole("button", { name: /dismiss/i });
 		fireEvent.click(dismissBtn);
-		expect(screen.queryByText(/start free/i)).toBeNull();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
 	});
 });

--- a/apps/web/modules/marketing/home/components/StickyCta.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.tsx
@@ -75,7 +75,7 @@ export function StickyCta() {
 				) : (
 					<>
 						<p className="text-foreground text-sm font-medium whitespace-nowrap">
-							Start free — 10 credits, no card needed
+							Get 10 free credits — no credit card required
 						</p>
 						<Button size="sm" variant="primary" asChild>
 							<Link href="/auth/signup" onClick={handleCtaClick}>

--- a/apps/web/modules/saas/payments/components/PricingTable.test.tsx
+++ b/apps/web/modules/saas/payments/components/PricingTable.test.tsx
@@ -342,7 +342,7 @@ describe("PricingTable - a11y", () => {
 		render(<PricingTable />);
 		const ctaButtons = document.querySelectorAll("button[aria-label]");
 		const getStartedButtons = Array.from(ctaButtons).filter((btn) =>
-			btn.getAttribute("aria-label")?.includes("Get started with"),
+			btn.getAttribute("aria-label")?.includes("Start"),
 		);
 		expect(getStartedButtons.length).toBeGreaterThan(0);
 	});

--- a/apps/web/modules/saas/payments/components/PricingTable.tsx
+++ b/apps/web/modules/saas/payments/components/PricingTable.tsx
@@ -453,7 +453,7 @@ export function PricingTable({
 												aria-label={
 													userId || organizationId
 														? `Choose the ${title} plan`
-														: `Get started with the ${title} plan`
+														: isFree ? `Start free with the ${title} plan` : `Start 7-day free trial with the ${title} plan`
 												}
 												onClick={() =>
 													onSelectPlan(
@@ -465,7 +465,7 @@ export function PricingTable({
 											>
 												{userId || organizationId
 													? "Choose plan"
-													: "Get started"}
+													: isFree ? "Start free" : "Start 7-day free trial"}
 												<ArrowRightIcon className="ml-2 size-4" />
 											</Button>
 										)}

--- a/apps/web/modules/saas/payments/components/PricingTable.tsx
+++ b/apps/web/modules/saas/payments/components/PricingTable.tsx
@@ -453,7 +453,9 @@ export function PricingTable({
 												aria-label={
 													userId || organizationId
 														? `Choose the ${title} plan`
-														: isFree ? `Start free with the ${title} plan` : `Start 7-day free trial with the ${title} plan`
+														: isFree
+															? `Start free with the ${title} plan`
+															: `Start 7-day free trial with the ${title} plan`
 												}
 												onClick={() =>
 													onSelectPlan(
@@ -465,7 +467,9 @@ export function PricingTable({
 											>
 												{userId || organizationId
 													? "Choose plan"
-													: isFree ? "Start free" : "Start 7-day free trial"}
+													: isFree
+														? "Start free"
+														: "Start 7-day free trial"}
 												<ArrowRightIcon className="ml-2 size-4" />
 											</Button>
 										)}

--- a/apps/web/modules/saas/tools/components/ToolsGrid.tsx
+++ b/apps/web/modules/saas/tools/components/ToolsGrid.tsx
@@ -112,7 +112,8 @@ export function ToolsGrid() {
 	const searchRef = useRef<HTMLDivElement>(null);
 	const { recentSearches, addSearch, removeSearch } = useRecentSearches();
 	const allTools = useMemo(() => getVisibleTools(), []);
-	const { recentToolSlugs, recentToolsMap } = useRecentJobs(20);
+	const { recentToolSlugs, recentToolsMap, isLoading, isError } =
+		useRecentJobs(20);
 	const recentToolSet = useMemo(
 		() => new Set(recentToolSlugs),
 		[recentToolSlugs],
@@ -369,12 +370,19 @@ export function ToolsGrid() {
 							<ToolCard
 								tool={tool}
 								isComingSoon={tool.isComingSoon}
-								isRecentlyUsed={recentToolSet.has(tool.slug)}
+								isRecentlyUsed={
+									!isLoading &&
+									!isError &&
+									recentToolSet.has(tool.slug)
+								}
 								lastUsedAt={
-									recentToolsMap.get(tool.slug)
-										?.completedAt ??
-									recentToolsMap.get(tool.slug)?.createdAt ??
-									null
+									!isLoading && !isError
+										? (recentToolsMap.get(tool.slug)
+												?.completedAt ??
+											recentToolsMap.get(tool.slug)
+												?.createdAt ??
+											null)
+										: null
 								}
 								isFavorite={isFavorite(tool.slug)}
 								onToggleFavorite={toggleFavorite}


### PR DESCRIPTION
## Changes\n- Pricing table buttons: 'Start 7-day free trial' for paid plans (anonymous users), 'Start free' for free plan.\n- Sticky CTA copy: 'Get 10 free credits — no credit card required'.\n- Fixed missing loading/error state for recent jobs in ToolsGrid (hides 'Recently used' badges while data is loading or errored).\n\n## Why\nClarity between free plan (no trial) and paid plans (7-day trial) improves conversion. Loading state fix improves UX.