### PR TITLE
fix(sticky-cta): hide CTA when credits balance fetch fails

### DIFF
--- a/apps/web/modules/marketing/home/components/StickyCta.test.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.test.tsx
@@ -21,6 +21,7 @@ type CreditsBalanceMock = {
 	isFreePlan: boolean;
 	isStarterPlan: boolean;
 	isLoading: boolean;
+	isError: boolean;
 	balance: { plan: { id: string; name: string } } | undefined;
 };
 
@@ -49,6 +50,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: undefined,
 		});
 	});
@@ -67,6 +69,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: undefined,
 		});
 		render(<StickyCta />);
@@ -79,6 +82,7 @@ describe("StickyCta", () => {
 			isFreePlan: true,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "free", name: "Free" } },
 		});
 		render(<StickyCta />);
@@ -91,6 +95,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: true,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "starter", name: "Starter" } },
 		});
 		render(<StickyCta />);
@@ -108,6 +113,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: true,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "starter", name: "Starter" } },
 		});
 		render(<StickyCta />);
@@ -120,6 +126,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "pro", name: "Pro" } },
 		});
 		render(<StickyCta />);
@@ -134,6 +141,7 @@ describe("StickyCta", () => {
 			isFreePlan: false,
 			isStarterPlan: false,
 			isLoading: true,
+			isError: false,
 			balance: undefined,
 		});
 		render(<StickyCta />);
@@ -146,6 +154,7 @@ describe("StickyCta", () => {
 			isFreePlan: true,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "free", name: "Free" } },
 		});
 		render(<StickyCta />);
@@ -160,6 +169,7 @@ describe("StickyCta", () => {
 			isFreePlan: true,
 			isStarterPlan: false,
 			isLoading: false,
+			isError: false,
 			balance: { plan: { id: "free", name: "Free" } },
 		});
 		render(<StickyCta />);
@@ -167,5 +177,20 @@ describe("StickyCta", () => {
 		const dismissBtn = screen.getByRole("button", { name: /dismiss/i });
 		fireEvent.click(dismissBtn);
 		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
+	});
+
+	it("hides when credits balance fetch fails", () => {
+		mockUseCreditsBalance.mockReturnValue({
+			isFreePlan: false,
+			isStarterPlan: false,
+			isLoading: false,
+			isError: true,
+			balance: undefined,
+		});
+		render(<StickyCta />);
+		// Should not show CTA at all, regardless of scroll
+		scrollPast400();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
+		expect(screen.queryByText(/upgrade to pro/i)).toBeNull();
 	});
 });

--- a/apps/web/modules/marketing/home/components/StickyCta.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.tsx
@@ -10,9 +10,30 @@ import React, { useEffect, useState } from "react";
 export function StickyCta() {
 	const [visible, setVisible] = useState(false);
 	const [dismissed, setDismissed] = useState(false);
-	const { isFreePlan, isStarterPlan, isLoading, balance } =
+	const { isFreePlan, isStarterPlan, isLoading, isError, balance } =
 		useCreditsBalance();
 	const { track } = useProductAnalytics();
+
+	useEffect(() => {
+		if (isError) {
+			// If we can't determine the user's plan, skip setting up scroll listener.
+			return;
+		}
+		// Show after user scrolls past ~400px (past the hero fold)
+		const handleScroll = () => {
+			if (!dismissed) {
+				setVisible(window.scrollY > 400);
+			}
+		};
+
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, [dismissed, isError]);
+
+	if (isError) {
+		// If we can't determine the user's plan, hide the CTA to avoid misleading messaging.
+		return null;
+	}
 
 	const handleCtaClick = () => {
 		track({
@@ -23,18 +44,6 @@ export function StickyCta() {
 			},
 		});
 	};
-
-	useEffect(() => {
-		// Show after user scrolls past ~400px (past the hero fold)
-		const handleScroll = () => {
-			if (!dismissed) {
-				setVisible(window.scrollY > 400);
-			}
-		};
-
-		window.addEventListener("scroll", handleScroll, { passive: true });
-		return () => window.removeEventListener("scroll", handleScroll);
-	}, [dismissed]);
 
 	const handleDismiss = () => {
 		setDismissed(true);


### PR DESCRIPTION
When the credits balance query fails (isError: true), the StickyCta now hides completely instead of showing potentially misleading messaging. Also skips scroll listener setup in that case.