### PR TITLE
feat(pricing): add shadow to recommended plan for visual prominence

### DIFF
--- a/apps/web/modules/saas/payments/components/PricingTable.tsx
+++ b/apps/web/modules/saas/payments/components/PricingTable.tsx
@@ -263,6 +263,7 @@ export function PricingTable({
 								aria-labelledby={`pricing-plan-title-${planId}`}
 								className={cn("rounded-3xl border p-6", {
 									"border-2 border-primary": recommended,
+									"shadow-lg": recommended,
 								})}
 								data-test="price-table-plan"
 							>


### PR DESCRIPTION
Adds shadow-lg to recommended plan card for better visual distinction. Monetization experiment.