### PR TITLE
fix(StickyCta): hide CTA while loading plan to avoid misleading messaging

### DIFF
--- a/apps/web/modules/marketing/home/components/StickyCta.test.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.test.tsx
@@ -135,8 +135,8 @@ describe("StickyCta", () => {
 		expect(screen.queryByText(/upgrade to pro/i)).toBeNull();
 	});
 
-	it("is not suppressed while plan is still loading", () => {
-		// While loading we can't confirm Pro status — show the CTA
+	it("is suppressed while plan is still loading", () => {
+		// While loading we hide the CTA to avoid misleading messaging
 		mockUseCreditsBalance.mockReturnValue({
 			isFreePlan: false,
 			isStarterPlan: false,
@@ -146,7 +146,7 @@ describe("StickyCta", () => {
 		});
 		render(<StickyCta />);
 		scrollPast400();
-		expect(screen.getByText(/Get 10 free credits/i)).toBeTruthy();
+		expect(screen.queryByText(/Get 10 free credits/i)).toBeNull();
 	});
 
 	it("contains a signup link for anonymous/free users", () => {

--- a/apps/web/modules/marketing/home/components/StickyCta.tsx
+++ b/apps/web/modules/marketing/home/components/StickyCta.tsx
@@ -15,7 +15,7 @@ export function StickyCta() {
 	const { track } = useProductAnalytics();
 
 	useEffect(() => {
-		if (isError) {
+		if (isError || isLoading) {
 			// If we can't determine the user's plan, skip setting up scroll listener.
 			return;
 		}
@@ -28,9 +28,9 @@ export function StickyCta() {
 
 		window.addEventListener("scroll", handleScroll, { passive: true });
 		return () => window.removeEventListener("scroll", handleScroll);
-	}, [dismissed, isError]);
+	}, [dismissed, isError, isLoading]);
 
-	if (isError) {
+	if (isError || isLoading) {
 		// If we can't determine the user's plan, hide the CTA to avoid misleading messaging.
 		return null;
 	}


### PR DESCRIPTION
Prevents showing 'Get 10 free credits' or upgrade CTAs while the user's plan is still loading. This improves UX by avoiding misleading messaging for authenticated users whose plan hasn't been determined yet.