### PR TITLE
refine(pricing): improve plan value proposition copy

### DIFF
--- a/apps/web/modules/saas/payments/hooks/plan-data.tsx
+++ b/apps/web/modules/saas/payments/hooks/plan-data.tsx
@@ -15,7 +15,7 @@ export function usePlanData() {
 		free: {
 			title: "Free Starter",
 			description:
-				"Full source code, local evaluation, community support",
+				"Evaluate locally with full source code and community support. Perfect for trying before you buy.",
 			features: [
 				"10 credits/month",
 				"All tools included",
@@ -26,7 +26,7 @@ export function usePlanData() {
 		starter: {
 			title: "Pro License",
 			description:
-				"Priority updates, verified compatibility, direct support",
+				"Priority updates, verified compatibility, and direct support. Ready for production use.",
 			features: [
 				"100 credits/month",
 				"All tools included",
@@ -46,7 +46,7 @@ export function usePlanData() {
 		pro: {
 			title: "Enterprise",
 			description:
-				"Premium modules, dedicated setup, customization guidance",
+				"Premium modules, dedicated setup, and customization guidance. Built for teams.",
 			features: [
 				"500 credits/month",
 				"All tools included",


### PR DESCRIPTION
Improve the value proposition copy for each pricing tier to better communicate benefits and drive conversion.

- Free Starter: clarify local evaluation focus
- Pro License: emphasize production readiness
- Enterprise: highlight team orientation

This is a monetization conversion bet (priority 3).