### PR TITLE
feat(pricing): add money-back guarantee badge to Pro plan

### DIFF
--- a/apps/web/modules/saas/payments/components/PricingTable.tsx
+++ b/apps/web/modules/saas/payments/components/PricingTable.tsx
@@ -17,6 +17,7 @@ import {
 	CheckIcon,
 	CoinsIcon,
 	PhoneIcon,
+	ShieldCheckIcon,
 	StarIcon,
 } from "lucide-react";
 import Link from "next/link";
@@ -419,6 +420,13 @@ export function PricingTable({
 													</p>
 												);
 											})()}
+
+										{isProPlan && (
+											<div className="mt-3 flex items-center justify-start font-medium text-primary text-sm opacity-80">
+												<ShieldCheckIcon className="mr-2 size-4" />
+												30‑day money‑back guarantee
+											</div>
+										)}
 
 										{isEnterprise ? (
 											<Button


### PR DESCRIPTION
Adds a 30‑day money‑back guarantee badge to the Pro plan card in the pricing table, using a ShieldCheckIcon and the same styling as the trial‑days badge. This provides a low‑friction trust signal that may increase conversion.