### PR TITLE
fix(deps): update inngest to 3.54.0 for Vercel CVE

### DIFF
--- a/apps/web/inngest/functions/contract-analyzer.ts
+++ b/apps/web/inngest/functions/contract-analyzer.ts
@@ -67,7 +67,10 @@ export const contractAnalyzer = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:ContractAnalyzer] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/expense-categorizer.ts
+++ b/apps/web/inngest/functions/expense-categorizer.ts
@@ -67,7 +67,10 @@ export const expenseCategorizer = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:ExpenseCategorizer] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/feedback-analyzer.ts
+++ b/apps/web/inngest/functions/feedback-analyzer.ts
@@ -67,7 +67,10 @@ export const feedbackAnalyzer = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:FeedbackAnalyzer] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/gdpr-exporter.ts
+++ b/apps/web/inngest/functions/gdpr-exporter.ts
@@ -67,7 +67,10 @@ export const gdprExporter = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:GdprExporter] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/invoice-processor.ts
+++ b/apps/web/inngest/functions/invoice-processor.ts
@@ -67,7 +67,10 @@ export const invoiceProcessor = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:InvoiceProcessor] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/meeting-summarizer.ts
+++ b/apps/web/inngest/functions/meeting-summarizer.ts
@@ -67,7 +67,10 @@ export const meetingSummarizer = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:MeetingSummarizer] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/inngest/functions/news-analyzer.ts
+++ b/apps/web/inngest/functions/news-analyzer.ts
@@ -67,7 +67,10 @@ export const newsAnalyzer = inngest.createFunction(
 					},
 				);
 			} else {
-				await markJobFailed(toolJobId, result.error ?? "Unknown error");
+				await markJobFailed(
+					toolJobId,
+					String(result.error ?? "Unknown error"),
+				);
 				logger.error("[Inngest:NewsAnalyzer] Job failed", {
 					toolJobId,
 					error: result.error,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,7 +49,7 @@
 		"fumadocs-core": "15.8.5",
 		"fumadocs-ui": "15.8.5",
 		"hono": "4.11.9",
-		"inngest": "3.49.3",
+		"inngest": "3.54.0",
 		"input-otp": "1.4.2",
 		"js-cookie": "3.0.5",
 		"lucide-react": "0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: 4.11.9
         version: 4.11.9
       inngest:
-        specifier: 3.49.3
-        version: 3.49.3(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.11.9)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.3.6)
+        specifier: 3.54.0
+        version: 3.54.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.11.9)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.3.6)
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2662,6 +2662,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.203.0':
+    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
@@ -3150,6 +3154,12 @@ packages:
 
   '@opentelemetry/instrumentation-winston@0.57.0':
     resolution: {integrity: sha512-0MEeeyTd55OcXEd3SRkDwPvpb2equZ4kIADI7boVB9OYyaxAR2TB7jPX1IGORn1n/V+FXVWlYn9pQc2GuboJ+w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.203.0':
+    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -5172,6 +5182,14 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    resolution: {integrity: sha512-bvivhZU6U8TW4TKktYnjdTi+7GE4WxI8epaGjawalSKDunmxaA+4UVFQ+4tSCBvp2Scby+gnYNaTZSrtABfOlQ==}
+    engines: {node: '>=14'}
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    resolution: {integrity: sha512-xQcPxVrKr3yT9+ZEM3skYXikJc/ocZlGDIcsBQ3mMwL3Weq1QL7jx/uGLXvrSO2Yh0DWUjWI6Q/oiRCEUM6P8w==}
+    engines: {node: '>=14'}
+
   '@tybys/wasm-util@0.8.3':
     resolution: {integrity: sha512-Z96T/L6dUFFxgFJ+pQtkPpne9q7i6kIPYCFnQBHSgSPV9idTsKfIhCss0h5iM9irweZCatkrdeP8yi5uM1eX6Q==}
 
@@ -6143,6 +6161,9 @@ packages:
 
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -7416,6 +7437,9 @@ packages:
   immer@11.1.4:
     resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   import-in-the-middle@2.0.6:
     resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
@@ -7437,10 +7461,9 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  inngest@3.49.3:
-    resolution: {integrity: sha512-JH4VBcxmBh7J0QIk28yYNSlBs1q2wnlds20Sj4a1m8RXRSfDh+z6+Lq+WVpaHH0XolsPYwkRwUA9Gf540AcBmg==}
+  inngest@3.54.0:
+    resolution: {integrity: sha512-EBMgyRZt9rWUmc9GUdxznbO1CmyXKZi2CZPNxNTyZJyjZMXFhPiftq/lTKjhYXD9/WlqaVFVB2K7o8vDAkGs6w==}
     engines: {node: '>=20'}
-    deprecated: 'CRITICAL SECURITY: upgrade to >=3.54.0'
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
       '@vercel/node': '>=2.15.9'
@@ -9110,6 +9133,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
@@ -11883,6 +11910,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api-logs@0.203.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -12616,6 +12647,15 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.213.0
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15069,6 +15109,21 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@traceloop/ai-semantic-conventions@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@traceloop/instrumentation-anthropic@0.20.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@traceloop/ai-semantic-conventions': 0.20.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@tybys/wasm-util@0.8.3':
     dependencies:
       tslib: 2.8.1
@@ -16117,6 +16172,8 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.1: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -17517,6 +17574,13 @@ snapshots:
 
   immer@11.1.4: {}
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   import-in-the-middle@2.0.6:
     dependencies:
       acorn: 8.16.0
@@ -17541,7 +17605,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inngest@3.49.3(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.11.9)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.3.6):
+  inngest@3.54.0(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.11.9)(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -17554,6 +17618,7 @@ snapshots:
       '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
+      '@traceloop/instrumentation-anthropic': 0.20.0
       '@types/debug': 4.1.12
       '@types/ms': 2.1.0
       canonicalize: 1.0.8
@@ -19590,6 +19655,14 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
 
   require-in-the-middle@8.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Update inngest from 3.49.3 to 3.54.0 (minimum patch to satisfy Vercel's security gate)
- Fix type errors in 7 inngest function handlers (`String()` wrap for `result.error`)
- Vercel blocks all deployments with `errorCode: VULNERABLE_INNGEST_VERSION` for versions <3.54.0

## Test plan

- [x] TypeScript type-check passes
- [x] All pre-commit hooks pass
- [ ] Vercel deployment succeeds (the whole point of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)