### PR TITLE
chore: replace remaining Supabase references with Neon

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -159,7 +159,7 @@ jobs:
 
             **To enable preview deployments**, add the \`preview\` label to this PR.
 
-            > **Note**: CI checks (lint, type-check, tests) and Supabase preview branch (for E2E tests) are still running.`;
+            > **Note**: CI checks (lint, type-check, tests) and Neon preview branch (for E2E tests) are still running.`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/preview-env-sync.yml
+++ b/.github/workflows/preview-env-sync.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: number
       branch_name:
-        description: "Git branch name (for Supabase branch lookup)"
+        description: "Git branch name (for Neon branch lookup)"
         required: false
         type: string
 

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -196,10 +196,6 @@ const releases = [
 			},
 			{
 				type: "improvement" as const,
-				text: "Repo-owned Supabase CLI fallback so global install is optional",
-			},
-			{
-				type: "improvement" as const,
 				text: "Added pnpm worktree:create / resume / list / remove for parallel feature development",
 			},
 		],

--- a/apps/web/app/(marketing)/security/page.tsx
+++ b/apps/web/app/(marketing)/security/page.tsx
@@ -89,7 +89,7 @@ const securityPillars = [
 		icon: "🌐",
 		title: "Trusted Infrastructure",
 		description:
-			"Hosted on Vercel and Supabase — enterprise-grade cloud providers with SOC 2 Type II certifications, 99.9% uptime SLAs, and global CDN delivery.",
+			"Hosted on Vercel and Neon — enterprise-grade cloud providers with SOC 2 Type II certifications, 99.9% uptime SLAs, and global CDN delivery.",
 	},
 	{
 		icon: "🛡️",
@@ -110,7 +110,7 @@ const faqs = [
 	},
 	{
 		q: "Where is my data stored?",
-		a: "Data is stored in secure cloud infrastructure (Supabase / AWS), encrypted at rest and in transit. You can request deletion of your account and all associated data at any time.",
+		a: "Data is stored in secure cloud infrastructure (Neon / AWS), encrypted at rest and in transit. You can request deletion of your account and all associated data at any time.",
 	},
 	{
 		q: "How long are files kept?",
@@ -181,7 +181,7 @@ export default function SecurityPage() {
 								detail: "Edge network & deployment",
 							},
 							{
-								label: "Supabase",
+								label: "Neon",
 								detail: "SOC 2 Type II database",
 							},
 							{

--- a/apps/web/tests/avatar-upload.spec.ts
+++ b/apps/web/tests/avatar-upload.spec.ts
@@ -8,7 +8,7 @@ import { expect, test } from "./fixtures";
  *
  * Prerequisites for preview deployments:
  * - The test user (test@preview.local / TestPassword123) must exist
- * - This is seeded automatically in Supabase preview branches via seed.sql
+ * - This is seeded automatically in Neon preview branches via seed.sql
  */
 test.describe("avatar upload @avatar", () => {
 	// Use BASE_URL env var if provided, otherwise use the default from playwright.config.ts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Local development database
-# Replaces `supabase start` with a lightweight PostgreSQL container.
+# Lightweight PostgreSQL container for local dev (mirrors the Neon-hosted prod schema).
 #
 # Usage:
 #   docker compose up -d      # Start database

--- a/docs/architecture-diagrams.md
+++ b/docs/architecture-diagrams.md
@@ -21,7 +21,7 @@ flowchart TB
     end
 
     subgraph Data["Data Layer"]
-        Postgres[(PostgreSQL<br/>Supabase)]
+        Postgres[(PostgreSQL<br/>Neon)]
         S3[(S3 Storage)]
         Redis[(Redis Cache)]
     end
@@ -495,10 +495,9 @@ flowchart TB
         Worker[Background<br/>Workers]
     end
 
-    subgraph Supabase["Supabase"]
+    subgraph Neon["Neon"]
         DB[(PostgreSQL)]
         Branch[Preview<br/>Branches]
-        Auth2[Auth<br/>Extensions]
     end
 
     subgraph AWS["AWS"]
@@ -535,6 +534,7 @@ flowchart TB
 ## Usage
 
 To render these diagrams:
+
 1. **GitHub/GitLab**: Markdown preview renders Mermaid automatically
 2. **VS Code**: Install "Markdown Preview Mermaid Support" extension
 3. **Online**: Paste into [mermaid.live](https://mermaid.live)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -316,7 +316,7 @@ model ToolJob {
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
   newsAnalysisId String?        @unique
-  audioFileUrl   String?        // S3/Supabase storage URL for audio files (speaker-separation)
+  audioFileUrl   String?        // S3 storage URL for audio files (speaker-separation)
   audioMetadata  Json?          // Audio file metadata: { filename, mimeType, duration, size }
   user           User?          @relation(fields: [userId], references: [id], onDelete: Cascade)
   newsAnalysis   NewsAnalysis?  @relation(fields: [newsAnalysisId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
## Summary

Cleans up stale Supabase mentions in user-facing copy and infra config left over from the Supabase → Neon migration (#1501, #1512). No functional changes.

- **Marketing pages** (`security`, `changelog`): Supabase → Neon, dropped defunct Supabase CLI bullet
- **CI workflows** (`preview-deploy.yml`, `preview-env-sync.yml`): PR-comment + workflow_dispatch descriptions say "Neon"
- **Architecture diagrams**: Postgres provider Supabase → Neon
- **Code comments** (`schema.prisma`, `avatar-upload.spec.ts`, `docker-compose.yml`): Supabase wording removed

## Intentionally not touched

- `migration.sql` comment — modifying an applied migration file changes its Prisma checksum and would break existing databases
- `.gitignore` — defensive guard for stale Supabase CLI cache; comment is accurate
- Historical `docs/research/*` and `tasks/*` — preserved as historical record
- The Render/pg-boss subgraphs in `architecture-diagrams.md` are also stale but out of scope here

## Test plan

- [ ] Marketing `/security` page renders "Neon" in trust strip and FAQ
- [ ] Marketing `/changelog` page no longer mentions Supabase CLI
- [ ] CI passes (lint, type-check, tests, markdown lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)